### PR TITLE
Add concurrent task 1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/example/concurrency/ConcurrencyApplication.java
+++ b/src/main/java/com/example/concurrency/ConcurrencyApplication.java
@@ -1,13 +1,31 @@
 package com.example.concurrency;
 
+import com.example.concurrency.services.ConcurrencyService;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class ConcurrencyApplication{
+@AllArgsConstructor
+@Slf4j
+public class ConcurrencyApplication implements CommandLineRunner {
+
+    private final ConcurrencyService concurrencyService;
 
     public static void main(String[] args) {
         SpringApplication.run(ConcurrencyApplication.class, args);
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        // These fix the issue
+        // concurrencyService.runWithConcurrentHashMap();
+        // concurrencyService.runWithSynchronizedMap();
+
+        // Throw the error
+        concurrencyService.runWithHashMap();
     }
 
 }

--- a/src/main/java/com/example/concurrency/services/ConcurrencyService.java
+++ b/src/main/java/com/example/concurrency/services/ConcurrencyService.java
@@ -1,0 +1,99 @@
+package com.example.concurrency.services;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@Slf4j
+public class ConcurrencyService {
+
+    public void runWithConcurrentHashMap() {
+        Map<Integer, Integer> map = new ConcurrentHashMap<>();
+
+        Thread thread1 = new Thread(() -> {
+            for (int i = 0; i < 1000; i++) {
+                map.put(i, i);
+            }
+        });
+
+        Thread thread2 = new Thread(() -> {
+            for (Integer key : map.keySet()) {
+                log.info("ConcurrentHashMap {}", map.get(key));
+            }
+        });
+
+        thread1.start();
+        thread2.start();
+
+        try {
+            thread1.join();
+            thread2.join();
+        } catch (InterruptedException e) {
+            log.error("Thread interrupted", e);
+        }
+
+        log.info("Size of ConcurrentHashMap: {}", map.size());
+    }
+
+    public void runWithSynchronizedMap() {
+        Map<Integer, Integer> map = Collections.synchronizedMap(new HashMap<>());
+
+        Thread thread1 = new Thread(() -> {
+            for (int i = 0; i < 1000; i++) {
+                map.put(i, i);
+            }
+        });
+
+        Thread thread2 = new Thread(() -> {
+            synchronized(map) {
+                for (Integer key : map.keySet()) {
+                    log.info("synchronizedMap {}", map.get(key));
+                }
+            }
+        });
+
+        thread1.start();
+        thread2.start();
+
+        try {
+            thread1.join();
+            thread2.join();
+        } catch (InterruptedException e) {
+            log.error("Thread interrupted", e);
+        }
+
+        log.info("Size of synchronizedMap: {}", map.size());
+    }
+
+    public void runWithHashMap() {
+        Map<Integer, Integer> map = new HashMap<>();
+
+        Thread thread1 = new Thread(() -> {
+            for (int i = 0; i < 1000; i++) {
+                map.put(i, i);
+            }
+        });
+
+        Thread thread2 = new Thread(() -> {
+            for (Integer key : map.keySet()) {
+                log.info("HashMap {}", map.get(key));
+            }
+        });
+
+        thread1.start();
+        thread2.start();
+
+        try {
+            thread1.join();
+            thread2.join();
+        } catch (InterruptedException e) {
+            log.error("Thread interrupted", e);
+        }
+
+        log.info("Size of HashMap: {}", map.size());
+
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+logging.level.com.example.concurrency=DEBUG


### PR DESCRIPTION
### Task 1 - Das Experiment

Create HashMap<Integer, Integer>. The first thread adds elements into the map, the other go along the given map and sum the values. Threads should work before catching ConcurrentModificationException. Try to fix the problem with ConcurrentHashMap and Collections.synchronizedMap(). What has happened after simple Map implementation exchanging? How it can be fixed in code? Try to write your custom ThreadSafeMap with synchronization and without. Run your samples with different versions of Java (6, 8, and 10, 11) and measure the performance. Provide a simple report to your mentor.
